### PR TITLE
Make the TestEngine a global dotnet tool (similar to neoxp)

### DIFF
--- a/src/Neo.TestEngine/Neo.TestEngine.csproj
+++ b/src/Neo.TestEngine/Neo.TestEngine.csproj
@@ -15,6 +15,8 @@
     <Product>TestingEngine</Product>
     <Description>TestingEngine</Description>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>neotest</ToolCommandName>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
Added more elements in the .csproj to pack it properly.
The package is created using `dotnet pack` and it needs to be uploaded at [NuGet](https://www.nuget.org/) using a Microsoft account. It can be called using the command `neotest`.